### PR TITLE
Using oninput instead of onkeyup

### DIFF
--- a/FasterTablesFilter.php
+++ b/FasterTablesFilter.php
@@ -77,7 +77,7 @@ class FasterTablesFilter {
 			}
 			appendTables();
 		};
-		filter.onkeyup = function(event) {
+		filter.oninput = function(event) {
 			filterTableList();
 		}
 		filterTableList();


### PR DESCRIPTION
The `input` event is better, because it fires for any modification of the text (either by typing with the keyboard or by changing using the mouse), and it doesn't fire for arrow keys.

It is probably a good idea to refactor the JavaScript a little bit, using `addEventListener` instead of `window.onload`, and wrap everything inside an anonymous function. This would prevent conflicts if multiple plugins define the same functions/variables. Maybe better/faster if hide/show elements instead of recreating them all the time?